### PR TITLE
use income statements endpoint

### DIFF
--- a/client.go
+++ b/client.go
@@ -45,7 +45,7 @@ func (c Client) UseVXEndpoints() Client {
 	return c
 }
 
-// polygon api versions are not unified, sometimes we have to switch to financials v1
+// UseFinancialsV1Endpoints switches to financials v1 as polygon api versions are not unified.
 func (c Client) UseFinancialsV1Endpoints() Client {
 	c.baseURL = strings.Replace(c.baseURL, "v2", "stocks/financials/v1", 1)
 	return c

--- a/client.go
+++ b/client.go
@@ -45,6 +45,12 @@ func (c Client) UseVXEndpoints() Client {
 	return c
 }
 
+// polygon api versions are not unified, sometimes we have to switch to financials v1
+func (c Client) UseFinancialsV1Endpoints() Client {
+	c.baseURL = strings.Replace(c.baseURL, "v2", "stocks/financials/v1", 1)
+	return c
+}
+
 // Error represents an Polygon API error
 type Error struct {
 	Status       string `json:"status"`

--- a/dividend_detail_test.go
+++ b/dividend_detail_test.go
@@ -15,6 +15,6 @@ func TestDividend(t *testing.T) {
 	}
 	t.Logf("dividend: %+v", dividend)
 
-	dividend, err = client.LastestDiviend(context.Background(), "COIN", &DividendOption{Limit: 1})
+	_, err = client.LastestDiviend(context.Background(), "COIN", &DividendOption{Limit: 1})
 	assert.Error(t, err)
 }

--- a/financials.go
+++ b/financials.go
@@ -82,6 +82,8 @@ type FinancialsOption struct {
 var ErrFinancialsNoResults = errors.New("no financials results")
 
 // Financials Retrieve historical financial data for a specified stock ticker
+//
+// Deprecated: This API is deprecated and will be removed in a future version.
 func (c Client) Financials(ctx context.Context, ticker string, opt *FinancialsOption) (resp Financials, err error) {
 	c = c.UseVXEndpoints()
 	ticker = strings.ToUpper(strings.TrimSpace(ticker))

--- a/financials_test.go
+++ b/financials_test.go
@@ -45,9 +45,7 @@ type MockClient struct{}
 func (c MockClient) UseVXEndpoints() Client {
 	return Client{}
 }
-func (c MockClient) endpointWithOpts(endpoint string, opt interface{}) (string, error) {
-	return "mock_endpoint", nil
-}
+
 func (c MockClient) GetJSON(ctx context.Context, endpoint string, v interface{}) error {
 	f := v.(*Financials)
 	*f = Financials{

--- a/income_statements.go
+++ b/income_statements.go
@@ -33,8 +33,8 @@ type IncomeStatement struct {
 	EquityInAffiliates                          float64  `json:"equity_in_affiliates"`
 	ExtraordinaryItems                          float64  `json:"extraordinary_items"`
 	FilingDate                                  string   `json:"filing_date"`
-	FiscalQuarter                               float64  `json:"fiscal_quarter"`
-	FiscalYear                                  float64  `json:"fiscal_year"`
+	FiscalQuarter                               int      `json:"fiscal_quarter"`
+	FiscalYear                                  int      `json:"fiscal_year"`
 	GrossProfit                                 float64  `json:"gross_profit"`
 	IncomeBeforeIncomeTaxes                     float64  `json:"income_before_income_taxes"`
 	IncomeTaxes                                 float64  `json:"income_taxes"`

--- a/income_statements.go
+++ b/income_statements.go
@@ -93,7 +93,7 @@ func (c Client) IncomeStatements(ctx context.Context, opt *IncomeStatementsOptio
 		err = ErrIncomeStatementsNoResults
 		return
 	}
-	return resp, err
+	return
 }
 
 // GetRevenue helper returns the revenue for a statement period.

--- a/income_statements.go
+++ b/income_statements.go
@@ -1,0 +1,100 @@
+package polygon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// IncomeStatementsResponse top-level response for the new income statements endpoint.
+// This endpoint replaces the deprecated Financials endpoint.
+type IncomeStatementsResponse struct {
+	Results   []IncomeStatement `json:"results"`
+	Status    string            `json:"status"`
+	RequestID string            `json:"request_id"`
+	NextURL   string            `json:"next_url"`
+}
+
+// IncomeStatement represents a single income statement period (annual, quarterly, or trailing twelve months)
+// Only a subset of fields are modeled explicitly; additional numeric fields can be added as needed.
+// The Polygon docs list these numeric metrics as numbers; we use float64. Optional fields default to zero if missing.
+type IncomeStatement struct {
+	BasicEarningsPerShare                       float64  `json:"basic_earnings_per_share"`
+	BasicSharesOutstanding                      float64  `json:"basic_shares_outstanding"`
+	CIK                                         string   `json:"cik"`
+	ConsolidatedNetIncomeLoss                   float64  `json:"consolidated_net_income_loss"`
+	CostOfRevenue                               float64  `json:"cost_of_revenue"`
+	DepreciationDepletionAmortization           float64  `json:"depreciation_depletion_amortization"`
+	DilutedEarningsPerShare                     float64  `json:"diluted_earnings_per_share"`
+	DilutedSharesOutstanding                    float64  `json:"diluted_shares_outstanding"`
+	DiscontinuedOperations                      float64  `json:"discontinued_operations"`
+	EBITDA                                      float64  `json:"ebitda"`
+	EquityInAffiliates                          float64  `json:"equity_in_affiliates"`
+	ExtraordinaryItems                          float64  `json:"extraordinary_items"`
+	FilingDate                                  string   `json:"filing_date"`
+	FiscalQuarter                               float64  `json:"fiscal_quarter"`
+	FiscalYear                                  float64  `json:"fiscal_year"`
+	GrossProfit                                 float64  `json:"gross_profit"`
+	IncomeBeforeIncomeTaxes                     float64  `json:"income_before_income_taxes"`
+	IncomeTaxes                                 float64  `json:"income_taxes"`
+	InterestExpense                             float64  `json:"interest_expense"`
+	InterestIncome                              float64  `json:"interest_income"`
+	NetIncomeLossAttributableCommonShareholders float64  `json:"net_income_loss_attributable_common_shareholders"`
+	NoncontrollingInterest                      float64  `json:"noncontrolling_interest"`
+	OperatingIncome                             float64  `json:"operating_income"`
+	OtherIncomeExpense                          float64  `json:"other_income_expense"`
+	OtherOperatingExpenses                      float64  `json:"other_operating_expenses"`
+	PeriodEnd                                   string   `json:"period_end"`
+	PreferredStockDividendsDeclared             float64  `json:"preferred_stock_dividends_declared"`
+	ResearchDevelopment                         float64  `json:"research_development"`
+	Revenue                                     float64  `json:"revenue"`
+	SellingGeneralAdministrative                float64  `json:"selling_general_administrative"`
+	Tickers                                     []string `json:"tickers"`
+	Timeframe                                   string   `json:"timeframe"` // quarterly | annual | trailing_twelve_months
+	TotalOperatingExpenses                      float64  `json:"total_operating_expenses"`
+	TotalOtherIncomeExpense                     float64  `json:"total_other_income_expense"`
+}
+
+// IncomeStatementsOption holds query params for the income statements endpoint.
+type IncomeStatementsOption struct {
+	CIK           string `url:"cik,omitempty"`
+	Tickers       string `url:"tickers,omitempty"`     // matches API expecting a value contained in array
+	PeriodEnd     string `url:"period_end,omitempty"`  // YYYY-MM-DD
+	FilingDate    string `url:"filing_date,omitempty"` // YYYY-MM-DD
+	FiscalYear    string `url:"fiscal_year,omitempty"`
+	FiscalQuarter string `url:"fiscal_quarter,omitempty"`
+	Timeframe     string `url:"timeframe,omitempty"` // quarterly, annual, trailing_twelve_months
+	Limit         uint   `url:"limit,omitempty"`     // default 100, max 50000
+	Sort          string `url:"sort,omitempty"`      // e.g. period_end.desc
+}
+
+var ErrIncomeStatementsNoResults = errors.New("no income statements results")
+
+// IncomeStatements retrieves income statements data. This replaces the deprecated Financials endpoint.
+func (c Client) IncomeStatements(ctx context.Context, opt *IncomeStatementsOption) (resp IncomeStatementsResponse, err error) {
+	c = c.UseFinancialsV1Endpoints()
+	if opt == nil {
+		opt = new(IncomeStatementsOption)
+	}
+	endpoint, err := c.endpointWithOpts("/income-statements", opt)
+	if err != nil {
+		return
+	}
+	if err = c.GetJSON(ctx, endpoint, &resp); err != nil {
+		err = fmt.Errorf("get json: %w", err)
+		return
+	}
+	if strings.ToUpper(resp.Status) != "OK" {
+		err = fmt.Errorf("%v: %w", resp.Status, ErrIncomeStatementsNoResults)
+		return
+	}
+	if len(resp.Results) == 0 {
+		err = ErrIncomeStatementsNoResults
+		return
+	}
+	return resp, err
+}
+
+// GetRevenue helper returns the revenue for a statement period.
+func (is IncomeStatement) GetRevenue() float64 { return is.Revenue }

--- a/income_statements_test.go
+++ b/income_statements_test.go
@@ -1,0 +1,44 @@
+package polygon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestIncomeStatement_GetRevenue(t *testing.T) {
+	stmt := IncomeStatement{Revenue: 1234.56}
+	if got := stmt.GetRevenue(); got != 1234.56 {
+		t.Errorf("GetRevenue() = %v, want %v", got, 1234.56)
+	}
+}
+
+func TestIncomeStatementsOption_Defaults(t *testing.T) {
+	opt := IncomeStatementsOption{}
+	if opt.Limit != 0 { // zero means use API default (100)
+		t.Errorf("Limit default = %v, want 0", opt.Limit)
+	}
+}
+
+func Test_IncomeStatements(t *testing.T) {
+	ctx := context.Background()
+	c := NewClient(token)
+	resp, err := c.IncomeStatements(ctx, &IncomeStatementsOption{Limit: 1})
+	if err != nil {
+		t.Fatal(fmt.Errorf("income statements: %w", err))
+	}
+	if len(resp.Results) == 0 {
+		t.Error("unexpected empty results")
+	}
+}
+
+func Test_IncomeStatementsNotFound(t *testing.T) {
+	ctx := context.Background()
+	c := NewClient(token)
+	// Use invalid CIK expecting no results (depends on API behavior).
+	_, err := c.IncomeStatements(ctx, &IncomeStatementsOption{CIK: "0000000000", Limit: 1})
+	if !errors.Is(err, ErrIncomeStatementsNoResults) {
+		t.Skip("API may return OK empty or different error; adjust once behavior confirmed. got:", err)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Income statements endpoint available for retrieving detailed financial statements with multiple filter options.
  * Added an option to switch to the Financials V1 endpoint for API access.

* **Deprecations**
  * Older Financials endpoint marked deprecated; prefer the new Income Statements endpoint.

* **Tests**
  * Added and updated unit tests for income statements and related behaviors.

* **Bug Fixes**
  * Minor test cleanup to avoid unintended variable capture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->