### PR TITLE
fix: add retry to the polygon requests

### DIFF
--- a/client.go
+++ b/client.go
@@ -218,8 +218,10 @@ func (c *Client) getBytes(ctx context.Context, address string) ([]byte, error) {
 			if !isGoAwayOrConnError(err) {
 				return []byte{}, err
 			}
-			time.Sleep(time.Duration(1<<uint(i)) * 100 * time.Millisecond) // exponential backoff
-			continue                                                // retry
+			if i < maxRetries-1 {
+				time.Sleep(time.Duration(1<<uint(i)) * 100 * time.Millisecond) // exponential backoff
+			}
+			continue // retry
 		}
 		defer resp.Body.Close()
 		// Even if GET didn't return an error, check the status code to make sure

--- a/client.go
+++ b/client.go
@@ -218,7 +218,7 @@ func (c *Client) getBytes(ctx context.Context, address string) ([]byte, error) {
 			if !isGoAwayOrConnError(err) {
 				return []byte{}, err
 			}
-			time.Sleep(time.Duration(i+1) * 100 * time.Millisecond) // exponential backoff
+			time.Sleep(time.Duration(1<<uint(i)) * 100 * time.Millisecond) // exponential backoff
 			continue                                                // retry
 		}
 		defer resp.Body.Close()

--- a/client_test.go
+++ b/client_test.go
@@ -40,7 +40,7 @@ func TestGetBytesRetry(t *testing.T) {
 	client.httpClient.Transport = rt
 
 	ctx := context.Background()
-	data, err := client.getBytes(ctx, "/v1/test-endpoint")
+	data, err := client.getBytes(ctx, "/v1/test-endpoint", true)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -68,7 +68,7 @@ func TestGetBytesNoRetrySuccess(t *testing.T) {
 	client.httpClient.Transport = rt
 
 	ctx := context.Background()
-	data, err := client.getBytes(ctx, "/v1/test-endpoint")
+	data, err := client.getBytes(ctx, "/v1/test-endpoint", true)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,81 @@
+package polygon
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+)
+
+type mockRoundTripper struct {
+	calls int
+	errs  []error
+	resps []*http.Response
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	defer func() { m.calls++ }()
+	if m.calls < len(m.errs) {
+		return m.resps[m.calls], m.errs[m.calls]
+	}
+	return nil, errors.New("no more mock responses")
+}
+
+func TestGetBytesRetry(t *testing.T) {
+	goawayErr := errors.New("http2: server sent GOAWAY and closed the connection; LastStreamID=1")
+	body := io.NopCloser(bytes.NewBufferString(`{"status":"OK"}`))
+	successResp := &http.Response{
+		StatusCode: 200,
+		Body:       body,
+	}
+
+	rt := &mockRoundTripper{
+		errs:  []error{goawayErr, nil},
+		resps: []*http.Response{nil, successResp},
+	}
+
+	client := NewClient("test-api-key")
+	client.httpClient.Transport = rt
+
+	ctx := context.Background()
+	data, err := client.getBytes(ctx, "/v1/test-endpoint")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if string(data) != `{"status":"OK"}` {
+		t.Fatalf("expected response body to be %s, got %s", `{"status":"OK"}`, string(data))
+	}
+	if rt.calls != 2 {
+		t.Fatalf("expected 2 calls to RoundTrip, got %d", rt.calls)
+	}
+}
+
+func TestGetBytesNoRetrySuccess(t *testing.T) {
+	body := io.NopCloser(bytes.NewBufferString(`{"status":"OK"}`))
+	successResp := &http.Response{
+		StatusCode: 200,
+		Body:       body,
+	}
+
+	rt := &mockRoundTripper{
+		errs:  []error{nil},
+		resps: []*http.Response{successResp},
+	}
+
+	client := NewClient("test-api-key")
+	client.httpClient.Transport = rt
+
+	ctx := context.Background()
+	data, err := client.getBytes(ctx, "/v1/test-endpoint")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if string(data) != `{"status":"OK"}` {
+		t.Fatalf("expected response body to be %s, got %s", `{"status":"OK"}`, string(data))
+	}
+	if rt.calls != 1 {
+		t.Fatalf("expected 1 call to RoundTrip, got %d", rt.calls)
+	}
+}

--- a/open_close.go
+++ b/open_close.go
@@ -33,7 +33,7 @@ func (c Client) StockOpenClose(ctx context.Context, ticker string, date string, 
 	if err != nil {
 		return p, err
 	}
-	err = c.GetJSON(ctx, endpoint, &p)
+	err = c.GetJSONWithRetries(ctx, endpoint, &p)
 	return p, err
 }
 
@@ -45,6 +45,6 @@ func (c Client) CryptoOpenClose(ctx context.Context, from, to string, date strin
 	if err != nil {
 		return p, err
 	}
-	err = c.GetJSON(ctx, endpoint, &p)
+	err = c.GetJSONWithRetries(ctx, endpoint, &p)
 	return p, err
 }

--- a/prev_close.go
+++ b/prev_close.go
@@ -54,6 +54,6 @@ func (c Client) PrevClose(ctx context.Context, ticker string, opt *PrevCloseOpti
 	if err != nil {
 		return p, err
 	}
-	err = c.GetJSON(ctx, endpoint, &p)
+	err = c.GetJSONWithRetries(ctx, endpoint, &p)
 	return p, err
 }


### PR DESCRIPTION
Actually we got this message from woodstock-jobs-monitoring.
```
failed to get prev open close price from polygon for QBTS on 2025-12-03. error: Get "https://api.polygon.io/v1/open-close/QBTS/2025-12-03?apiKey=2tEh027mTxp6gnYs0d_pUfVH2Atjadcr": http2: server sent GOAWAY and closed the connection; LastStreamID=199, ErrCode=NO_ERROR, debug=""
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic retries with exponential backoff for transient HTTP errors (connection resets/GOAWAY) and HTTP 502/503/504.
  * Retry-enabled fetching for JSON, raw bytes, and numeric endpoints to improve reliability.
  * Improved reporting of non-200 responses with clearer status and error messages.

* **Tests**
  * Unit tests added to validate retry behavior and no-retry success scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->