### PR TITLE
fix: data truncation from different time type

### DIFF
--- a/aggregation.go
+++ b/aggregation.go
@@ -65,7 +65,9 @@ type AggregationOption struct {
 // Aggregation Get aggregate bars for a ticker over a given date range in custom time window sizes
 func (c Client) Aggregation(ctx context.Context, ticker string, multiplier int, timespan Timespan, from, to time.Time, opt *AggregationOption) (Aggregation, error) {
 	a := Aggregation{}
-	endpoint, err := c.endpointWithOpts(fmt.Sprintf("/aggs/ticker/%s/range/%d/%s/%s/%s", ticker, multiplier, timespan, ttoa(from), ttoa(to)), opt)
+	// If we use dates, returned data will be truncated to only include data withiin this year.
+	// Use unix milliseconds to get full data.
+	endpoint, err := c.endpointWithOpts(fmt.Sprintf("/aggs/ticker/%s/range/%d/%s/%d/%d", ticker, multiplier, timespan, from.UnixMilli(), to.UnixMilli()), opt)
 	if err != nil {
 		return a, err
 	}


### PR DESCRIPTION
polygon's api sucks
https://massive.com/docs/rest/stocks/aggregates/custom-bars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data retrieval to ensure complete historical data is returned instead of being truncated to the current year.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->